### PR TITLE
:arrow_up: Update ipfs version to 0.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "browserify": "^14.4.0",
     "http-server": "^0.10.0",
-    "ipfs": "^0.25.2",
+    "ipfs": "^0.26.0",
     "y-array": "^10.1.4",
     "y-ipfs-connector": "^1.2.1",
     "y-memory": "^8.0.9",


### PR DESCRIPTION
I updated ipfs version in order to avoid the folowing message "Uncaught Error: no protocol with name: p2p-webrtc-star".

This issue seems to have been resolved the same way here: 

- https://github.com/ipfs-shipyard/ipfs-pubsub-room/issues/12
- https://github.com/ipfs-shipyard/ipfs-pubsub-room/commit/e19cc8cac360fc08db245ab007ae334a6008e9f9